### PR TITLE
[Feature #156165089] Add document delete resource

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -29,7 +29,12 @@ class DocumentsController < ApplicationController
       render 'edit'
     end
   end
-  
+  def destroy
+    @document = Document.find(params[:id])
+    @document.destroy
+ 
+    redirect_to documents_path
+  end
   private
   def document_params
       params.require(:document).permit(:title, :text)

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -13,6 +13,9 @@
       <td><%= document.text %></td>
       <td><%= link_to 'Show', document_path(document) %></td>
       <td><%= link_to 'Edit', edit_document_path(document) %></td>
+      <td><%= link_to 'Destroy', document_path(document),
+              method: :delete,
+              data: { confirm: 'Are you sure?' } %></td>
     </tr>
   <% end %>
 </table>


### PR DESCRIPTION
What does this PR do?

Add delete functionality for documents.

Description of Task to be completed?

Currently:
Documents cannot be deleted

Expected:
When delete confirm button is hit, the document is removed permanently from the database

How should this be manually tested?
After hitting the delete button, the document in question should disappear completely from the document list.

What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/n/projects/2158208 #156165089