### PR TITLE
[Feature #156176252] Update document delete ensure reviews are deleted

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,5 +1,5 @@
 class Document < ApplicationRecord
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
   validates :title, presence: true,
                     length: { minimum: 5 }
   validates :text, presence: true,


### PR DESCRIPTION
What does this PR do?

Ensures that when a document is deleted, its reviews are also removed from the database permanently.

Description of Task to be completed?

Currently:
Current when a document is deleted, it reviews are still stored in the database

Expected:
When a document is deleted, its reviews are permanently removed from the database

How should this be manually tested?
N/A

What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/n/projects/2158208 #156176252